### PR TITLE
solve double quotes with XPA_DLL

### DIFF
--- a/deps/gencode.c
+++ b/deps/gencode.c
@@ -146,7 +146,11 @@ int main(int argc, char* argv[])
   fprintf(output, "\n");
   fprintf(output, "# Path to the XPA dynamic library.\n");
 #ifdef XPA_DLL
-  fprintf(output, "const libxpa = \"%s\"\n", XPA_DLL);
+  if (XPA_DLL[0] == '"') {
+    fprintf(output, "const libxpa = %s\n", XPA_DLL);
+  } else {
+    fprintf(output, "const libxpa = \"%s\"\n", XPA_DLL);
+  }
 #endif /* XPA_DLL */
 
   return 0;

--- a/deps/getdll.sh
+++ b/deps/getdll.sh
@@ -16,7 +16,7 @@ case `uname` in
         dll=$(ldd "$EXE" | sed -n "$script")
         ;;
     Darwin)
-        script='/lib'$LIB'\.dylib/{s/^[ \t]*//;s/[ \t]*([^)]*)[ \t]*$//;p}'
+        script='/lib'$LIB'\.dylib/{s/^[ \t]*//;s/[ \t]*([^)]*)[ \t]*$//;p;}'
         dll=$(otool -L "$EXE" | sed -n "$script")
         ;;
     *)

--- a/deps/getdll.sh
+++ b/deps/getdll.sh
@@ -16,7 +16,7 @@ case `uname` in
         dll=$(ldd "$EXE" | sed -n "$script")
         ;;
     Darwin)
-        script='/lib'$LIB'\.dylib/{s/^[ \t]*//;s/[ \t]*([^)]*)[ \t]*$//;p;}'
+        script='/lib'$LIB'[0-9.]*\.dylib/{s/^[[:space:]]*//;s/[ \t]*([^)]*)[ \t]*$//;p;}'
         dll=$(otool -L "$EXE" | sed -n "$script")
         ;;
     *)


### PR DESCRIPTION
When ENV["XPA_DLL"] = "/path/to/libxpa.dylib" is defined in julia, we end up with:
const libxpa = ""/Users/michel/local/libxpa.dylib"" in deps.jl. Then, when precompiling in julia, this yields:
ERROR: LoadError: LoadError: syntax: "/" is not a unary operator
